### PR TITLE
Stop Photos from opening automatically

### DIFF
--- a/scripts/configuration-osx.sh
+++ b/scripts/configuration-osx.sh
@@ -17,3 +17,5 @@ defaults write /Users/pivotal/Library/Preferences/.GlobalPreferences InitialKeyR
 # set finder to display full path in title bar
 defaults write com.apple.finder '_FXShowPosixPathInTitle' -bool true
 
+# stop Photos from opening automatically
+defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true


### PR DESCRIPTION
- very handy on an iOS project or when someone wants to charge their phone.

To revert use: defaults -currentHost delete com.apple.ImageCapture disableHotPlug
